### PR TITLE
Update cosign installer action

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -40,7 +40,7 @@ jobs:
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@7e0881f8fe90b25e305bbf0309761e9314607e25
+        uses: sigstore/cosign-installer@1fc5bd396d372bee37d608f955b336615edf79c8
         with:
           cosign-release: "v1.9.0"
 


### PR DESCRIPTION
Cosign switched to downloading releases from github rather than the GCS bucket a few months ago:
https://github.com/sigstore/cosign-installer/pull/126
Guess they finally took the bucket down

The old script fails to download the release now
```
% curl -sL  https://storage.googleapis.com/cosign-releases/v1.9.0/cosign-linux-amd64
<?xml version='1.0' encoding='UTF-8'?><Error><Code>AccessDenied</Code><Message>Access denied.</Message><Details>Anonymous caller does not have storage.objects.get access to the Google Cloud Storage object. Permission 'storage.objects.get' denied on resource (or it may not exist).</Details></Error>%                                                                         
```
                                                                                                                                                          
The command from the new script works
```
% curl -sL https://github.com/sigstore/cosign/releases/download/v1.9.0/cosign-linux-amd64 -o cosign  
```